### PR TITLE
Fix routes not showing on the world map.

### DIFF
--- a/Routes.lua
+++ b/Routes.lua
@@ -1067,7 +1067,7 @@ RoutesPinMixin = CreateFromMixins(MapCanvasPinMixin)
 
 function RoutesPinMixin:OnLoad()
 	self:SetIgnoreGlobalPinScale(true)
-	self:UseFrameLevelType("PIN_FRAME_LEVEL_SCENARIO_BLOB")
+	self:UseFrameLevelType("PIN_FRAME_LEVEL_MAP_EXPLORATION")
 end
 
 function RoutesPinMixin:OnAcquired(battleField)


### PR DESCRIPTION
Routes show fine on the minimap, but in the worldmap they are getting overlapped by other frames.