### PR TITLE
Fix all plugins broken nil and deprecation

### DIFF
--- a/Plugins/GatherLite.lua
+++ b/Plugins/GatherLite.lua
@@ -18,9 +18,9 @@ do
 
     -- stop loading if the addon is not enabled, or
     -- stop loading if there is a reason why it can't be loaded ("MISSING" or "DISABLED")
-    local enabled = GetAddOnEnableState(UnitName("player"), SourceName)
-    local name, title, notes, loadable, reason, security = GetAddOnInfo(SourceName)
-    if not enabled or (reason ~= nil and reason ~= "" and reason ~= "DEMAND_LOADED") then
+    local enabled = C_AddOns.GetAddOnEnableState(UnitName("player"), SourceName)
+    local name, title, notes, loadable, reason, security = C_AddOns.GetAddOnInfo(SourceName)
+    if not enabled or (reason ~= "" and reason ~= "" and reason ~= "DEMAND_LOADED") then
         loaded = false
         return
     end

--- a/Plugins/GatherMate2.lua
+++ b/Plugins/GatherMate2.lua
@@ -19,9 +19,9 @@ do
 
 	-- stop loading if the addon is not enabled, or
 	-- stop loading if there is a reason why it can't be loaded ("MISSING" or "DISABLED")
-	local enabled = GetAddOnEnableState(UnitName("player"), SourceName)
-	local name, title, notes, loadable, reason, security = GetAddOnInfo(SourceName)
-	if not enabled or (reason ~= nil and reason ~= "" and reason ~= "DEMAND_LOADED") then
+	local enabled = C_AddOns.GetAddOnEnableState(UnitName("player"), SourceName)
+	local name, title, notes, loadable, reason, security = C_AddOns.GetAddOnInfo(SourceName)
+	if not enabled or (reason ~= "" and reason ~= "" and reason ~= "DEMAND_LOADED") then
 		loaded = false
 		return
 	end

--- a/Plugins/Gatherer.lua
+++ b/Plugins/Gatherer.lua
@@ -18,9 +18,9 @@ do
 
 	-- stop loading if the addon is not enabled, or
 	-- stop loading if there is a reason why it can't be loaded ("MISSING" or "DISABLED")
-	local enabled = GetAddOnEnableState(UnitName("player"), SourceName)
-	local name, title, notes, loadable, reason, security = GetAddOnInfo(SourceName)
-	if not enabled or (reason ~= nil and reason ~= "" and reason ~= "DEMAND_LOADED") then
+	local enabled = C_AddOns.GetAddOnEnableState(UnitName("player"), SourceName)
+	local name, title, notes, loadable, reason, security = C_AddOns.GetAddOnInfo(SourceName)
+	if not enabled or (reason ~= "" and reason ~= "" and reason ~= "DEMAND_LOADED") then
 		loaded = false
 		return
 	end

--- a/Plugins/HandyNotes.lua
+++ b/Plugins/HandyNotes.lua
@@ -19,9 +19,9 @@ do
 
 	-- stop loading if the addon is not enabled, or
 	-- stop loading if there is a reason why it can't be loaded ("MISSING" or "DISABLED")
-	local enabled = GetAddOnEnableState(UnitName("player"), SourceName)
-	local name, title, notes, loadable, reason, security = GetAddOnInfo(SourceName)
-	if not enabled or (reason ~= nil and reason ~= "" and reason ~= "DEMAND_LOADED") then
+	local enabled = C_AddOns.GetAddOnEnableState(UnitName("player"), SourceName)
+	local name, title, notes, loadable, reason, security = C_AddOns.GetAddOnInfo(SourceName)
+	if not enabled or (reason ~= "" and reason ~= "" and reason ~= "DEMAND_LOADED") then
 		loaded = false
 		return
 	end


### PR DESCRIPTION
This fixes gathermate2 not working in some cases, and other plugins have the same issue.

There's also lines in each plugin that use deprecated API that get fixed in this patch.