### PR TITLE
Fix auto show/hide for Classic era

### DIFF
--- a/Modules/AutoShow.lua
+++ b/Modules/AutoShow.lua
@@ -77,6 +77,9 @@ function AutoShow:SKILL_LINES_CHANGED()
 end
 
 function AutoShow:MINIMAP_UPDATE_TRACKING()
+	if WOW_PROJECT_ID == WOW_PROJECT_CLASSIC then
+		return self:UNIT_AURA()
+	end
 	for i = 1, GetNumTrackingTypes() do
 		local name, texture, active, category  = GetTrackingInfo(i)
 		if tracking_spells[name] then


### PR DESCRIPTION
Tested on Anniversary servers.

C_Minimap.GetNumTrackingTypes always returns 0 in Classic era and UNIT_AURA doesn't trigger on at least Find Herbs (not sure about Find Minerals).